### PR TITLE
add a new parameter - strategy to qa

### DIFF
--- a/src/byzerllm/apps/builder.py
+++ b/src/byzerllm/apps/builder.py
@@ -24,8 +24,9 @@ class OnceWay:
             if i.is_file():
                with open(i.as_posix(),"r",encoding="utf-8") as f:
                  for line in f:
-                    doc = json.loads(line)                    
-                    docs.append(Document(page_content=doc["page_content"],metadata={ "source":doc["source"]}))
+                    doc = json.loads(line)
+                    docs.append(Document(page_content=doc["page_content"],
+                                         metadata={"source": doc["source"], "page_content": doc["page_content"]}))
                     
 
         if  len(docs) > 0:

--- a/src/byzerllm/apps/qa_strategy.py
+++ b/src/byzerllm/apps/qa_strategy.py
@@ -1,0 +1,86 @@
+from langchain.docstore.document import Document
+from abc import ABC, abstractmethod
+from typing import List, Tuple
+
+
+class DocRetrieveStrategy(ABC):
+    @abstractmethod
+    def retrieve(self, docs: List[Tuple[Document, float]], k: int) -> List[Tuple[Document, float]]:
+        pass
+
+
+class FullDocRetrieveStrategy(DocRetrieveStrategy):
+    def retrieve(self, docs: List[Tuple[Document, float]], k: int) -> List[Tuple[Document, float]]:
+        if docs is None or len(docs) == 0:
+            print("empty doc list")
+            return None
+
+        doc_hits = {}
+        for doc in docs:
+            if doc[0].metadata['source'] in doc_hits:
+                doc_hits[doc[0].metadata['source']] = (doc[0], doc[1], doc_hits[doc[0].metadata['source']][2] + 1)
+            else:
+                doc_hits[doc[0].metadata['source']] = (doc[0], doc[1], 1)
+        # Sort by hits descending and then by score ascending
+        sorted_docs = sorted(doc_hits.values(), key=lambda x: (x[2], -1 * x[1]), reverse=True)
+        doc_tuple3 = sorted_docs[0]
+        doc_tuple3[0].page_content = doc_tuple3[0].metadata['page_content']
+        return [(doc_tuple3[0], doc_tuple3[1])]
+
+
+class DocRetrieveStrategyFactory(DocRetrieveStrategy):
+    def __init__(self, strategy: str) -> None:
+        self.strategy = strategy
+
+    def retrieve(self, docs: List[Tuple[Document, float]], k: int) -> List[Tuple[Document, float]]:
+        if self.strategy == "full_doc":
+            print("Using full_doc strategy")
+            return FullDocRetrieveStrategy().retrieve(docs, k)
+        else:
+            return docs
+
+
+class DocCombineFormat(ABC):
+    @abstractmethod
+    def combine(self, docs: List[Tuple[Document, float]], k: int) -> Tuple[List, List]:
+        pass
+
+
+class FullDocCombineFormatList(DocCombineFormat):
+    def combine(self, docs: List[Tuple[Document, float]], k: int) -> Tuple[List, List]:
+        if docs is None or len(docs) == 0:
+            return None
+
+        temp_docs = []
+        temp_metas = []
+        for index, doc in enumerate(docs[0:k]):
+            temp_docs.append(f'{index}. {doc[0].page_content}')
+            if "metadata" in doc[0]:
+                temp_metas.append(doc[0].metadata)
+        return (temp_docs, temp_metas)
+
+
+class FullDocCombineFormatDefault(DocCombineFormat):
+    def combine(self, docs: List[Tuple[Document, float]], k: int) -> Tuple[List, List]:
+        if docs is None or len(docs) == 0:
+            return None
+
+        temp_docs = []
+        temp_metas = []
+        for index, doc in enumerate(docs[0:k]):
+            temp_docs.append(f'{doc[0].page_content}')
+            if "metadata" in doc[0]:
+                temp_metas.append(doc[0].metadata)
+        return (temp_docs, temp_metas)
+
+
+class FullDocCombineFormatFactory(DocCombineFormat):
+    def __init__(self, format: str) -> None:
+        self.format = format
+
+    def combine(self, docs: List[Tuple[Document, float]], k: int) -> Tuple[List, List]:
+        if self.format == 'list':
+            return FullDocCombineFormatList().combine(docs, k)
+        else:
+            return FullDocCombineFormatDefault().combine(docs, k)
+


### PR DESCRIPTION
## Change Description
This pr aims to improve the document quality, which is fed to LLM as context. The new logic is as follows:
1. Search vector DB by similarity for matching chunks
2. Each chunk relates to a document, and sort documents by hitting number in descending and score in ascending order.
3. Pick the document with most hits and lowest score and feed to the LLM as context

## Usage
Follow the instructions in [Byzer-LLM 构建基于大模型问答知识库](https://docs.byzer.org/#/byzer-lang/zh-cn/byzer-llm/qa). 

Increase the token max length and specify strategy in the question step, for example 
```sql
select llm_response_predict(
docs_qa(llm_param(map(
"instruction","what's Byzer?",
"k",10,
"prompt","${template}",
"temperature", 0.1,
"max_length", 8192,
"strategy", "full_doc"
)))
) as response as output;
```

## Test result
![image](https://github.com/allwefantasy/byzer-llm/assets/12869649/2d4b9729-8360-4529-bdde-4a2be34bc9de)


